### PR TITLE
chor(package.json): Enable node12 nodenext moduleResolution support for typescript-4.7 support

### DIFF
--- a/packages/@straw-hat/fancy-map/package.json
+++ b/packages/@straw-hat/fancy-map/package.json
@@ -26,6 +26,8 @@
   },
   "type": "commonjs",
   "main": "dist/index.js",
+  "exports": "dist/index.js",
+  "types": "dist/index.d.ts",
   "typings": "dist/index.d.ts",
   "files": [
     "dist",


### PR DESCRIPTION
made compatible with node12 nodenext resolve as this package got only a single export we could even drop the marker propertys typings and types but its a good idea to add them to speed up moduleResolution and also make it more easy for tooling like bundlers to consume that package

if a package only got a main you can add a equal exports: fild not as object as single string as i did here this will make the package compatible to node12 and nodenext moduleResolution modes without any additional changes. 

the trick is here that when exports exist it is authoritativ when there is a index.cjs referenced it will lookup index.d.cts without a extra types fild so the exports: "" fild is the new main fild and a additional types fild is not needed the main and typings and types fild simply stay for compat with tooling and moduleResolution: node

node12 and nodenext are covered with the single exports: line and a correct named type declaration file 

.js => d.ts
.cjs => d.cts
.mjs => d.mts