### PR TITLE
Add OpenAPI web SDK package support metadata

### DIFF
--- a/packages/@straw-hat/openapi-web-sdk-generator/package.json
+++ b/packages/@straw-hat/openapi-web-sdk-generator/package.json
@@ -7,6 +7,10 @@
     "url": "https://github.com/straw-hat-team/nodejs-monorepo.git",
     "directory": "packages/@straw-hat/openapi-web-sdk-generator"
   },
+  "homepage": "https://github.com/straw-hat-team/nodejs-monorepo/tree/master/packages/@straw-hat/openapi-web-sdk-generator#readme",
+  "bugs": {
+    "url": "https://github.com/straw-hat-team/nodejs-monorepo/issues"
+  },
   "license": "MIT",
   "keywords": [
     "openapi",


### PR DESCRIPTION
## Summary
- add npm homepage metadata for @straw-hat/openapi-web-sdk-generator
- add the package bug tracker URL

## Verification
- node package manifest assertion
- git diff --check
- npm pack --dry-run --ignore-scripts --json ./packages/@straw-hat/openapi-web-sdk-generator